### PR TITLE
add Vaillant ecoTEC 0010024646 configuration and models

### DIFF
--- a/ebusd-2.1.x/de/vaillant/bai.0010024646.inc
+++ b/ebusd-2.1.x/de/vaillant/bai.0010024646.inc
@@ -1,0 +1,60 @@
+# type (r[1-9];w;u),circuit,name,[comment],[QQ],ZZ,PBSB,[ID],field1,part (m/s),datatypes/templates,divider/values,unit,comment
+#,BAI00,Vaillant ecoTEC,0010024646,,,,,,,,,,
+*r,,,,,,"B509","0D",,,,,,
+*w,,,,,,"B509","0E",,,,,,
+*wi,#install,,,,,"B509","0E",,,,,,
+*ws,#service,,,,,"B509","0E",,,,,,
+*[SW],scan,,,SW,,,,,,,,,
+# ##### Diagnose Ebene 1 #####,,,,,,,,,,,,,
+r,,Statenumber,Statenumber_DK,,,,"AB00",,,UCH,,,status number
+r;wi,,PartloadHcKW,d.00 Heizungsteillast,,,,"0704",,,power,,,Heizungsteillast
+r;wi,,WPPostrunTime,d.01 Pumpennachlaufzeit,,,,"F703",,,minutes0,,,Wasserpumpennachlaufzeit nach Heizbetrieb
+r;wi,,BlockTimeHcMax,d.02 Maximale Brennersperrzeit,,,,"0904",,,minutes0,,,Max. Brennersperrzeit bei einem Vorlaufsollwert von 20°C
+r,,HwcTemp,d.03 WW Vorlaufsolltemp,,,,"1600",,,tempsensor,,,Vorlauftemperatur bei Warmwasserzapfung (nur bei Kombi-Heizgeräten)
+r,,StorageTemp,d.04 Speicheristtemp,,,,"1700",,,tempsensor,,,Aktuelle Temperatur des Warmstartspeichers (bei Kombigeräten) oder aktuelle Speichertemperatur bei (VC Geräten)
+r,,FlowTempDesired,d.05 Vorlaufsolltemperatur,,,,"3900",,,temp,,,Vorlaufsolltemperatur oder Rücklaufsolltemperatur (wenn Rücklaufregelung aktiviert wurde). Der Maximalwert wird über d.71 und einem eBUS Regler begrenzt.
+r,,StorageTempDesired,d.07 Speichersolltemp,,,,"0400",,,temp,,,VCW: Solltemperatur des WarmstartspeichersVC: Solltemperatur des externen Speichers
+r,,ACRoomthermostat,d.08 Raumthermostat,,,,"2A00",,,onoff,,,Status des extrenen Raumthermostat an Klemme 3/4
+r,,ExtFlowTempDesiredMin,d.09 Min. ext. Vorlaufsollwert,,,,"6E04",,,temp,,,minimum out of Kl.7 and eBus flow setpoint
+r,,WP,d.10 Wasserpumpe,,,,"4400",,,onoff,,,Interne Heizungspumpe
+r,,ExtWP,d.11 ext. Heizungspumpe,,,,"3F00",,,onoff,,,Externe Heizungspumpe
+r,,Storageloadpump,d.12 Speicherladepumpe,,,,"9E00",,,percent0,,,Ladepumpenanforderung
+r,,CirPump,d.13 Zirkulationspumpe,,,,"7B00",,,onoff,,,Status Zirkulationspumpe (über ein externes Modul ansteuerbar)
+r,,HwcDemand,d.22 WW Anforderung,,,,"5800",,,yesno,,,Warmwasseranforderung (Zapfung oder Schaltkontakt)
+r,,HeatingSwitch,d.23 Winterbetrieb,,,,"F203",,,onoff,,,Wintermodus aktiv
+r,,StoragereleaseClock,d.25 Speicherfreigabe,,,,"4704",,,yesno,,,Speicherladung freigegeben durch eBus Regler
+r,,Gasvalve,d.30 Gasventil,,,,"BB00",,,onoff2,,,Gasventil angesteuert
+r,,TargetFanSpeed,d.33 Lüfter Solldrehzahl,,,,"2400",,,UIN,,rpm,Solldrehzahl des Lüfters
+r,,FanSpeed,d.34 Lüfteristdrehzahl,,,,"8300",,,UIN,,rpm,Aktuelle Drehzahl des Lüfters
+r,,PositionValveSet,d.35 Position VUV,,,,"5400",,,UCH,,,Position des 3-Wege Ventil: 100=Warmwasser, 0=Heizbetrieb, 40=Mittelstellung
+r,,FlowTemp,d.40 Vorlauftemperatur,,,,"1800",,,tempsensor,,,Vorlauftemperatur
+r,,ReturnTemp,d.41 Rücklauftemperatur,,,,"9800",,,tempmirrorsensor,,,Rücklauftemperatur
+r,,IonisationVoltageLevel,d.44 Digitaler Ionisationswert,,,,"A400",,,SIN,10,,Ionisationsspannung: größer 80 keine Flammekleiner 40 gute Flamme
+r,,OutdoorstempSensor,d.47 Außentemperaturfühler,,,,"7600",,,tempsensor,,,Außentemperatur (nicht korrigierter Wert)
+r,,RemainingBoilerblocktime,d.67 Verbleibende Brennersperrzeit,,,,"3800",,,minutes0,,,Verbleibende Brennersperrzeit
+r,,DeactivationsTemplimiter,d.60 STB Abschaltungen,,,,"2000",,,UCH,,,Anzahl der Abschaltungen durch den Sicherheitstemperaturbgrenzers
+r,,DeactivationsIFC,d.61 Anzahl Zündfehler,,,,"1F00",,,UCH,,,Anzahl der Zündfehler (erfolglose Zündung im letzten Versuch + Flammabbrüche)
+r,,AverageIgnitiontime,d.64 Mittlere Zündzeit,,,,"2D00",,,UCH,10,s,Mittlere Zündzeit
+r,,MaxIgnitiontime,d.65 Maximale Zündzeit,,,,"2C00",,,UCH,10,s,Maximale Zündzeit
+r,,CounterStartattempts1,d.68 Zündfehler 1. Versuch,,,,"6E00",,,temp0,,,Anzahl der erfolglosen Zündversuche (im 1. Versuch)
+r,,CounterStartattempts2,d.69 Zündfehler 2. Versuch,,,,"6F00",,,temp0,,,Anzahl der erfolglosen Zündversuche (im 2. Versuch)
+r,,EBusHeatcontrol,d.90 Digitaler Regler,,,,"0004",,,yesno,,,Status des digitalen Reglers
+r,,Flame,Flammensignal,,,,"0500",,,onoff2,,,Flammenstatus
+r,,FanHours,Betriebsstunden Lüfter,,,,"1B00",,,hoursum2,,h,Betriebsstunden des Lüfters
+r,,FanStarts,Schaltspiele Lüfter,,,,"1C00",,,cntstarts2,,,Anzahl der Lüfter-Einschaltungen
+r,,CounterStartAttempts3,Zündfehler 3. Versuch,,,,"8100",,,temp0,,,Anzahl der erfolglosen Zündversuche (im 3. Versuch)
+r,,CounterStartAttempts4,Zündfehler 4. Versuch,,,,"8200",,,temp0,,,Anzahl der erfolglosen Zündversuche (im 4. Versuch)
+r,,TempDiffBlock,TempDiffBlock,,,,"1200",,,temp0,,,Number of modulationblocking of the boilers cause of to high/incorrect difference of flow/return temperatures
+r,,TempDiffFailure,TempDiffFailure,,,,"1300",,,temp0,,,Anzahl der Abschaltungen wegen zu hoher / fehlerhafter Differenz von Vor- und Rücklauftemperatur
+r,,ValveStarts,3WV Schaltspiele,,,,"1A00",,,cntstarts2,,,Anzahl der 3WV Umschaltungen
+r,,TemplimiterWithNTC,TemplimiterWithNTC,,,,"D200",,,yesno2,,,Temperaturbegrenzer mit NTC
+r,,HcHours,HZ Betriebsstunden,,,,"3801",,,hoursum,,h,Betriebsstunden Heizbetrieb
+r,,HcPumpStarts,HZ Pumpen-Schaltspiele,,,,"5603",,,cntstarts3,,,Schaltspiele der Heizungspumpe
+r,,HcStarts,HZ Brennerstarts,,,,"3803",,,cntstarts2,,,Brennerstarts im Heizbetrieb
+r,,HwcHours,WW Betriebsstunden,,,,"7701",,,hoursum,,h,Betriebsstunden Warmwasserbetrieb
+r,,HwcStarts,WW Brennerstarts,,,,"7703",,,cntstarts2,,,Brennerstarts im Warmwasserbetrieb
+r,,PumpHours,Betriebsstunden Pumpe,,,,"5601",,,hoursum,,h,Pumpenbetriebsstunden
+r,,StorageLoadPumpHours,Speicherladepumpenlaufzeit,,,,"7301",,,hoursum,,h,Betriebsstunden der Speicherladepumpe
+r,,StorageloadPumpStarts,Speicherladepumpen-Schaltspiele,,,,"7303",,,cntstarts2,,,Schaltspiele der Speicherladepumpe
+r,,ValveMode,Ventilmodus,,,,"F403",,,UCH,,,Ventilmodus
+r,,HcPumpMode,Pumpenmodus Heizung,,,,"4E04",,,pumpmode,,,Pumpenmodus Heizung 

--- a/ebusd-2.1.x/en/vaillant/bai.0010024646.inc
+++ b/ebusd-2.1.x/en/vaillant/bai.0010024646.inc
@@ -1,0 +1,60 @@
+# type (r[1-9];w;u),circuit,name,[comment],[QQ],ZZ,PBSB,[ID],field1,part (m/s),datatypes/templates,divider/values,unit,comment
+#,BAI00,Vaillant ecoTEC,0010024646,,,,,,,,,,
+*r,,,,,,"B509","0D",,,,,,
+*w,,,,,,"B509","0E",,,,,,
+*wi,#install,,,,,"B509","0E",,,,,,
+*ws,#service,,,,,"B509","0E",,,,,,
+*[SW],scan,,,SW,,,,,,,,,
+# ##### dia level 1 #####,,,,,,,,,,,,,
+r,,Statenumber,Statenumber_DK,,,,"AB00",,,UCH,,,status number
+r;wi,,PartloadHcKW,d.00 heating partload,,,,"0704",,,power,,,Heating part load
+r;wi,,WPPostrunTime,d.01 central heating overruntime,,,,"F703",,,minutes0,,,water pump overrun time for heating mode
+r;wi,,BlockTimeHcMax,d.02 Max blocking time CH,,,,"0904",,,minutes0,,,max. burner anti cycling period at 20°C Flow temperature setpoint
+r,,HwcTemp,d.03 Temp DHW,,,,"1600",,,tempsensor,,,hot water flow temperature (combination boiler only)
+r,,StorageTemp,d.04 Temp storage / she,,,,"1700",,,tempsensor,,,current temperature for warm start sensor (combination boiler only) Current storage tank sensor (system boiler only)
+r,,FlowTempDesired,d.05 flow/return setpoint,,,,"3900",,,temp,,,Flow temperature target value or return target value when return regulation is set
+r,,StorageTempDesired,d.07 Storage setpoint,,,,"0400",,,temp,,,"Warm start temperature value (combination boiler plus only), Storage temperature target value (system boiler only)"
+r,,ACRoomthermostat,d.08 Room thermostat 230 V,,,,"2A00",,,onoff,,,External controls heat demand (Clamp 3-4)
+r,,ExtFlowTempDesiredMin,d.09 ext flowsetpoint,,,,"6E04",,,temp,,,minimum out of Kl.7 and eBus flow setpoint
+r,,WP,d.10 Central heating pump,,,,"4400",,,onoff,,,internal heating pump
+r,,ExtWP,d.11 external pump,,,,"3F00",,,onoff,,,External heating pump
+r,,Storageloadpump,d.12 storage load pump,,,,"9E00",,,percent0,,,tank load pump demand
+r,,CirPump,d.13 Circulation pump,,,,"7B00",,,onoff,,,Hot water circulation pump (via external module)
+r,,HwcDemand,d.22 DHW demand,,,,"5800",,,yesno,,,domestic hot water (tapping or tank contact) demand
+r,,HeatingSwitch,d.23 operation mode,,,,"F203",,,onoff,,,Wintermode active
+r,,StoragereleaseClock,d.25 DHW demand enabled,,,,"4704",,,yesno,,,hot water release (tank storage) via eBus Control
+r,,Gasvalve,d.30 Gasvalve,,,,"BB00",,,onoff2,,,Gasvalve activation signal
+r,,TargetFanSpeed,d.33 Target fan speed,,,,"2400",,,UIN,,rpm,Fan speed setpoint
+r,,FanSpeed,d.34 Actual fan speed,,,,"8300",,,UIN,,rpm,fan speed actual value
+r,,PositionValveSet,d.35 Position TWV,,,,"5400",,,UCH,,,Position of diverter valve; 100 = DHW, 0 = heating, 40 = middle position
+r,,FlowTemp,d.40 TFT_DK,,,,"1800",,,tempsensor,,,flow temperature
+r,,ReturnTemp,d.41 Temp heating return,,,,"9800",,,tempmirrorsensor,,,return temperature
+r,,IonisationVoltageLevel,d.44 Dig. ionisation voltage,,,,"A400",,,SIN,10,,digital ionisation voltage> 80 no flame< 40 good flame
+r,,OutdoorstempSensor,d.47 Temp outside,,,,"7600",,,tempsensor,,,Outside temperature (uncorrected value)
+r,,RemainingBoilerblocktime,d.67 Remaining burner block time,,,,"3800",,,minutes0,,,Remaining burner anti cycling time
+r,,DeactivationsTemplimiter,d.60 Number STL cut off,,,,"2000",,,UCH,,,Number of safety temperature limiter cut offs
+r,,DeactivationsIFC,d.61 Number ignition device cut off,,,,"1F00",,,UCH,,,number of lock outs (unsuccessfull ignitons in the last attempt, flame failure)
+r,,AverageIgnitiontime,d.64 average ignition time,,,,"2D00",,,UCH,10,s,average ignition time
+r,,MaxIgnitiontime,d.65 Max ignition time,,,,"2C00",,,UCH,10,s,maximum ignition time
+r,,CounterStartattempts1,d.68 ignition attempts 1,,,,"6E00",,,temp0,,,unsuccessfull ignitions in the first attempt
+r,,CounterStartattempts2,d.69 ignition attempts 2,,,,"6F00",,,temp0,,,unsuccessfull ignitions in the second attempt
+r,,EBusHeatcontrol,d.90 Digital control recognized,,,,"0004",,,yesno,,,Digital regulator status
+r,,Flame,Flame,,,,"0500",,,onoff2,,,Flame status
+r,,FanHours,Fan operation hours,,,,"1B00",,,hoursum2,,h,Operating hours of the fan
+r,,FanStarts,FanCommunt_DK,,,,"1C00",,,cntstarts2,,,commutations of the fan
+r,,CounterStartAttempts3,CounterStartAttempts3_DK,,,,"8100",,,temp0,,,unsuccessfull ignitions in the third attempt
+r,,CounterStartAttempts4,CounterStartAttempts4_DK,,,,"8200",,,temp0,,,unsuccessfull ignitions in the fourth attempt
+r,,TempDiffBlock,TempDiffBlock_DK,,,,"1200",,,temp0,,,Number of modulationblocking of the boilers cause of to high/incorrect difference of flow/return temperatures
+r,,TempDiffFailure,TempDiffFailure_DK,,,,"1300",,,temp0,,,Number of cut offs of the boilers cause of to high/incorrect differences of flow/return temperatures
+r,,ValveStarts,TWV_Communt_DK,,,,"1A00",,,cntstarts2,,,commutations of the three way valve
+r,,TemplimiterWithNTC,TemplimiterWithNTC,,,,"D200",,,yesno2,,,Safety temperature limit concept
+r,,HcHours,HcHours,,,,"3801",,,hoursum,,h,Central heating operation hours
+r,,HcPumpStarts,HcPumpStarts,,,,"5603",,,cntstarts3,,,Central heating pump starts
+r,,HcStarts,HcStarts,,,,"3803",,,cntstarts2,,,Central heating burner starts
+r,,HwcHours,HwcHours,,,,"7701",,,hoursum,,h,Hot water operation hours
+r,,HwcStarts,HwcStarts,,,,"7703",,,cntstarts2,,,Hot water burner starts
+r,,PumpHours,PumpHours,,,,"5601",,,hoursum,,h,Pump operation hours
+r,,StorageLoadPumpHours,StorageLoadPumpHours,,,,"7301",,,hoursum,,h,Storage load pump operation hours
+r,,StorageloadPumpStarts,StorageloadPumpStarts,,,,"7303",,,cntstarts2,,,Storage load pump starts
+r,,ValveMode,ValveMode,,,,"F403",,,UCH,,,Valve mode
+r,,HcPumpMode,HcPumpMode,,,,"4E04",,,pumpmode,,,Heating pump mode 

--- a/src/vaillant/bai.0010024646_inc.tsp
+++ b/src/vaillant/bai.0010024646_inc.tsp
@@ -1,0 +1,356 @@
+import "@ebusd/ebus-typespec";
+import "./_templates.tsp";
+import "./errors_inc.tsp";
+import "./service_inc.tsp";
+using Ebus;
+using Ebus.Num;
+using Ebus.Dtm;
+using Ebus.Str;
+namespace Vaillant;
+
+namespace Bai._0010024646_inc {
+  // ,BAI00,Vaillant ecoTEC,0010024646
+
+  /** Statenumber_DK: status number */
+  @ext(0xab, 0)
+  model Statenumber is ReadonlyRegister<UCH>;
+
+  /** d.00 heating partload: Heating part load */
+  @ext(0x7, 0x4)
+  model PartloadHcKW is InstallRegister<power>;
+
+  /** d.01 central heating overruntime: water pump overrun time for heating mode */
+  @ext(0xf7, 0x3)
+  model WPPostrunTime is InstallRegister<minutes0>;
+
+  /** d.02 Max blocking time CH: max. burner anti cycling period at 20°C Flow temperature setpoint */
+  @ext(0x9, 0x4)
+  model BlockTimeHcMax is InstallRegister<minutes0>;
+
+  /** d.03 Temp DHW: hot water flow temperature (combination boiler only) */
+  @ext(0x16, 0)
+  model HwcTemp is ReadonlyRegister<tempsensor>;
+
+  /** d.04 Temp storage / she: current temperature for warm start sensor (combination boiler only) Current storage tank sensor (system boiler only) */
+  @ext(0x17, 0)
+  model StorageTemp is ReadonlyRegister<tempsensor>;
+
+  /** d.05 flow/return setpoint: Flow temperature target value or return target value when return regulation is set */
+  @ext(0x39, 0)
+  model FlowTempDesired is ReadonlyRegister<temp>;
+
+  /** d.07 Storage setpoint: Warm start temperature value (combination boiler plus only), Storage temperature target value (system boiler only) */
+  @ext(0x4, 0)
+  model StorageTempDesired is ReadonlyRegister<temp>;
+
+  /** d.08 Room thermostat 230 V: External controls heat demand (Clamp 3-4) */
+  @ext(0x2a, 0)
+  model ACRoomthermostat is ReadonlyRegister<onoff>;
+
+  /** d.09 ext flowsetpoint: minimum out of Kl.7 and eBus flow setpoint */
+  @ext(0x6e, 0x4)
+  model ExtFlowTempDesiredMin is ReadonlyRegister<temp>;
+
+  /** d.10 Central heating pump: internal heating pump */
+  @ext(0x44, 0)
+  model WP is ReadonlyRegister<onoff>;
+
+  /** d.11 external pump: External heating pump */
+  @ext(0x3f, 0)
+  model ExtWP is ReadonlyRegister<onoff>;
+
+  /** d.12 storage load pump: tank load pump demand */
+  @ext(0x9e, 0)
+  model Storageloadpump is ReadonlyRegister<percent0>;
+
+  /** d.13 Circulation pump: Hot water circulation pump (via external module) */
+  @ext(0x7b, 0)
+  model CirPump is ReadonlyRegister<onoff>;
+
+  /** d.22 DHW demand: domestic hot water (tapping or tank contact) demand */
+  @ext(0x58, 0)
+  model HwcDemand is ReadonlyRegister<yesno>;
+
+  /** d.23 operation mode: Wintermode active */
+  @ext(0xf2, 0x3)
+  model HeatingSwitch is ReadonlyRegister<onoff>;
+
+  /** d.25 DHW demand enabled: hot water release (tank storage) via eBus Control */
+  @ext(0x47, 0x4)
+  model StoragereleaseClock is ReadonlyRegister<yesno>;
+
+  /** d.30 Gasvalve: Gasvalve activation signal */
+  @ext(0xbb, 0)
+  model Gasvalve is ReadonlyRegister<onoff2>;
+
+  /** d.33 Target fan speed */
+  @inherit(r)
+  @ext(0x24, 0)
+  model TargetFanSpeed {
+    /** Fan speed setpoint */
+    @unit("1/min")
+    value: UIN;
+  }
+
+  /** d.34 Actual fan speed */
+  @inherit(r)
+  @ext(0x83, 0)
+  model FanSpeed {
+    /** fan speed actual value */
+    @unit("1/min")
+    value: UIN;
+  }
+
+  /** d.35 Position TWV: Position of diverter valve; 100 = DHW, 0 = heating, 40 = middle position */
+  @ext(0x54, 0)
+  model PositionValveSet is ReadonlyRegister<UCH>;
+
+  /** d.40 TFT_DK: flow temperature */
+  @ext(0x18, 0)
+  model FlowTemp is ReadonlyRegister<tempsensor>;
+
+  /** d.41 Temp heating return: return temperature */
+  @ext(0x98, 0)
+  model ReturnTemp is ReadonlyRegister<tempmirrorsensor>;
+
+  /** d.44 Dig. ionisation voltage */
+  @inherit(r)
+  @ext(0xa4, 0)
+  model IonisationVoltageLevel {
+    /** digital ionisation voltage> 80 no flame< 40 good flame */
+    @divisor(10)
+    value: SIN;
+  }
+
+  /** d.47 Temp outside: Outside temperature (uncorrected value) */
+  @ext(0x76, 0)
+  model OutdoorstempSensor is ReadonlyRegister<tempsensor>;
+
+  /** d.60 Number STL cut off: Number of safety temperature limiter cut offs */
+  @ext(0x20, 0)
+  model DeactivationsTemplimiter is ReadonlyRegister<UCH>;
+
+  /** d.61 Number ignition device cut off: number of lock outs (unsuccessfull ignitons in the last attempt, flame failure) */
+  @ext(0x1f, 0)
+  model DeactivationsIFC is ReadonlyRegister<UCH>;
+
+  /** d.64 average ignition time */
+  @inherit(r)
+  @ext(0x2d, 0)
+  model AverageIgnitiontime {
+    /** average ignition time */
+    @unit("s")
+    @divisor(10)
+    value: UCH;
+  }
+
+  /** d.65 Max ignition time */
+  @inherit(r)
+  @ext(0x2c, 0)
+  model MaxIgnitiontime {
+    /** maximum ignition time */
+    @unit("s")
+    @divisor(10)
+    value: UCH;
+  }
+
+  /** d.67 Remaining burner block time: Remaining burner anti cycling time */
+  @ext(0x38, 0)
+  model RemainingBoilerblocktime is ReadonlyRegister<minutes0>;
+
+  /** d.68 ignition attempts 1: unsuccessfull ignitions in the first attempt */
+  @ext(0x6e, 0)
+  model CounterStartattempts1 is ReadonlyRegister<temp0>;
+
+  /** d.69 ignition attempts 2: unsuccessfull ignitions in the second attempt */
+  @ext(0x6f, 0)
+  model CounterStartattempts2 is ReadonlyRegister<temp0>;
+
+  /** d.90 Digital control recognized: Digital regulator status */
+  @ext(0, 0x4)
+  model EBusHeatcontrol is ReadonlyRegister<yesno>;
+
+  /** Flame */
+  @ext(0x5, 0)
+  model Flame is ReadonlyRegister<onoff2>;
+
+  /** Fan operation hours */
+  @ext(0x1b, 0)
+  model FanHours is ReadonlyRegister<hoursum2>;
+
+  /** FanCommunt_DK: commutations of the fan */
+  @ext(0x1c, 0)
+  model FanStarts is ReadonlyRegister<cntstarts2>;
+
+  /** CounterStartAttempts3_DK: unsuccessfull ignitions in the third attempt */
+  @ext(0x81, 0)
+  model CounterStartAttempts3 is ReadonlyRegister<temp0>;
+
+  /** CounterStartAttempts4_DK: unsuccessfull ignitions in the fourth attempt */
+  @ext(0x82, 0)
+  model CounterStartAttempts4 is ReadonlyRegister<temp0>;
+
+  /** TempDiffBlock_DK: Number of modulationblocking of the boilers cause of to high/incorrect difference of flow/return temperatures */
+  @ext(0x12, 0)
+  model TempDiffBlock is ReadonlyRegister<temp0>;
+
+  /** TempDiffFailure_DK: Number of cut offs of the boilers cause of to high/incorrect differences of flow/return temperatures */
+  @ext(0x13, 0)
+  model TempDiffFailure is ReadonlyRegister<temp0>;
+
+  /** TWV_Communt_DK: commutations of the three way valve */
+  @ext(0x1a, 0)
+  model ValveStarts is ReadonlyRegister<cntstarts2>;
+
+  /** TemplimiterWithNTC: Safety temperature limit concept */
+  @ext(0xd2, 0)
+  model TemplimiterWithNTC is ReadonlyRegister<yesno2>;
+
+  /** HcHours: Central heating operation hours */
+  @ext(0x38, 1)
+  model HcHours is ReadonlyRegister<hoursum>;
+
+  /** HcPumpStarts: Central heating pump starts */
+  @ext(0x56, 0x3)
+  model HcPumpStarts is ReadonlyRegister<cntstarts3>;
+
+  /** HcStarts: Central heating burner starts */
+  @ext(0x38, 0x3)
+  model HcStarts is ReadonlyRegister<cntstarts2>;
+
+  /** HwcHours: Hot water operation hours */
+  @ext(0x77, 1)
+  model HwcHours is ReadonlyRegister<hoursum>;
+
+  /** HwcStarts: Hot water burner starts */
+  @ext(0x77, 0x3)
+  model HwcStarts is ReadonlyRegister<cntstarts2>;
+
+  /** PumpHours: Pump operation hours */
+  @ext(0x56, 1)
+  model PumpHours is ReadonlyRegister<hoursum>;
+
+  /** StorageLoadPumpHours: Storage load pump operation hours */
+  @ext(0x73, 1)
+  model StorageLoadPumpHours is ReadonlyRegister<hoursum>;
+
+  /** StorageloadPumpStarts: Storage load pump starts */
+  @ext(0x73, 0x3)
+  model StorageloadPumpStarts is ReadonlyRegister<cntstarts2>;
+
+  /** Valve mode */
+  @ext(0xf4, 0x3)
+  model ValveMode is ReadonlyRegister<UCH>;
+
+  /** HcPumpMode: Heating pump mode */
+  @ext(0x4e, 0x4)
+  model HcPumpMode is ReadonlyRegister<pumpmode>;
+
+  /** Dodane parametry na podstawie wyników komendy grab */
+
+  /** DisplayMode: Display operation mode */
+  @ext(0xda, 0)
+  model DisplayMode is ReadonlyRegister<UCH>;
+
+  /** WaterpressureMeasureCounter: Water pressure measurement counter */
+  @ext(0xf1, 0)
+  model WaterpressureMeasureCounter is ReadonlyRegister<UCH>;
+
+  /** HwcUnderHundredStarts: Hot water starts under hundred counter */
+  @ext(0x31, 0)
+  model HwcUnderHundredStarts is ReadonlyRegister<UCH>;
+
+  /** HcUnderHundredStarts: Heating starts under hundred counter */
+  @ext(0x30, 0)
+  model HcUnderHundredStarts is ReadonlyRegister<UCH>;
+
+  /** SHEMaxFlowTemp: Secondary heat exchanger maximum flow temperature */
+  @ext(0xc3, 0)
+  model SHEMaxFlowTemp is ReadonlyRegister<temp>;
+
+  /** HwcTempMax: Maximum hot water temperature */
+  @ext(0x43, 0x4)
+  model HwcTempMax is ReadonlyRegister<temp>;
+  
+  /** Maintenancedata_HwcTempMax: Maximum hot water temperature from maintenance data */
+  @ext(0x35, 0)
+  model Maintenancedata_HwcTempMax is ReadonlyRegister<temp>;
+
+  /** StorageTempMax: Maximum storage temperature */
+  @ext(0x36, 0)
+  model StorageTempMax is ReadonlyRegister<temp>;
+
+  /** FlowTempMax: Maximum flow temperature */
+  @ext(0x37, 0)
+  model FlowTempMax is ReadonlyRegister<temp>;
+
+  /** ReturnTempMax: Maximum return temperature */
+  @ext(0xbe, 0)
+  model ReturnTempMax is ReadonlyRegister<temp>;
+
+  /** ModulationTempDesired: Desired modulation temperature */
+  @ext(0x2e, 0)
+  model ModulationTempDesired is ReadonlyRegister<temp>;
+
+  /** PumpPower: Pump power value */
+  @ext(0x73, 0)
+  model PumpPower is ReadonlyRegister<UCH>;
+
+  /** PumpPowerDesired: Desired pump power */
+  @ext(0xa1, 0)
+  model PumpPowerDesired is ReadonlyRegister<UCH>;
+
+  /** HwcWaterflow: Hot water flow rate */
+  @ext(0x55, 0)
+  model HwcWaterflow is ReadonlyRegister<uin100>;
+
+  /** HwcWaterflowMax: Maximum hot water flow rate */
+  @ext(0x56, 0)
+  model HwcWaterflowMax is ReadonlyRegister<uin100>;
+
+  /** HwcImpellorSwitch: Hot water impellor switch */
+  @ext(0x57, 0)
+  model HwcImpellorSwitch is ReadonlyRegister<yesno>;
+
+  /** VortexFlowSensor: Vortex flow sensor value */
+  @ext(0xd5, 0)
+  model VortexFlowSensor is ReadonlyRegister<UIN>;
+
+  /** OverflowCounter: Overflow counter */
+  @ext(0x1e, 0)
+  model OverflowCounter is ReadonlyRegister<yesno>;
+
+  /** SecondPumpMode: Second pump mode */
+  @ext(0xb, 0x4)
+  model SecondPumpMode is ReadonlyRegister<UCH>;
+
+  /** ExternalHwcSwitch: External hot water circuit switch */
+  @ext(0x0, 0)
+  model ExternalHwcSwitch is ReadonlyRegister<onoff>;
+
+  /** HwcTempDesired: Hot water temperature desired value */
+  @ext(0xea, 0x3)
+  model HwcTempDesired is ReadonlyRegister<temp>;
+
+  /** WarmstartDemand: Warm start demand */
+  @ext(0x3a, 0x4)
+  model WarmstartDemand is ReadonlyRegister<onoff>;
+
+  /** Templimiter: Temperature limiter status */
+  @ext(0x77, 0)
+  model Templimiter is ReadonlyRegister<onoff>;
+
+  /** HoursTillService: Hours till next service */
+  @ext(0x20, 0x4)
+  model HoursTillService is ReadonlyRegister<ULG>;
+
+  /** TimerInputHc: Timer input for heating circuit */
+  @ext(0xde, 0)
+  model TimerInputHc is ReadonlyRegister<onoff>;
+
+  /** included parts */
+  union _includes {
+    Errors_inc,
+    Service_inc,
+  }
+} 


### PR DESCRIPTION
This pull request introduces significant updates to the configuration and type specification files for Vaillant ecoTEC boilers, specifically targeting the `BAI00` circuit (`0010024646`). The changes include adding new diagnostic parameters, expanding type specifications, and improving support for both German and English language files. These updates enhance the boiler's diagnostics and control capabilities by defining detailed registers and models for various operational parameters.

### Diagnostic Parameter Enhancements:
* Added extensive diagnostic entries to the German configuration file `ebusd-2.1.x/de/vaillant/bai.0010024646.inc`, covering parameters such as flow temperature, pump operations, ignition attempts, and burner states.
* Mirrored the German diagnostic entries in the English configuration file `ebusd-2.1.x/en/vaillant/bai.0010024646.inc`, with translations for comments and parameter descriptions.

### Type Specification Expansion:
* Introduced a new type specification file `src/vaillant/bai.0010024646_inc.tsp` that defines models for all diagnostic parameters, including their types, units, and descriptions. Examples include `FlowTemp`, `FanSpeed`, `HwcHours`, and `PumpPowerDesired`.
* Added support for additional operational parameters, such as `HoursTillService`, `WarmstartDemand`, and `ExternalHwcSwitch`, to provide more granular control and monitoring.

These changes aim to improve the comprehensiveness and usability of the boiler diagnostics and configuration system.